### PR TITLE
Added basic README including how to install and run the site locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 !/public/css
 
 *.un~
+# don't store user's override file in git
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -4,18 +4,39 @@ nodeguide.com
 Local installation
 ------------------
 
-### Linux - Debian/ Ubuntu
-
 ```bash
 git clone git@github.com:felixge/nodeguide.com.git
 cd nodeguide.com 
-sudo apt install pandoc # if you don't yet have pandoc installed
-make
 ```
 
 ### Viewing the Guide
 
+#### With Docker
+
+If you don't know what Docker is, then it will be easiest for you to view the **Without Docker** instructions, below.
+
+If you do not have a webserver (Apache/ Nginx) running, you will probably have port 80 available, in which case just run:
+
+```bash
+docker-compose up
+```
+
+If, however port 80 is already taken by a webserver (typical for a development environment), you will see an error like this: `Error starting userland proxy: listen tcp 0.0.0.0:80: listen: address already in use`.
+In which case, you can use the "override" file to make it use a different port (e.g. 8080 if that is available):
+
+```bash
+cp docker-compose.override.yml.dist docker-compose.override.yml
+docker-compose -f docker-compose.override.yml up
+```
+
+#### Without Docker - Debian/ Ubuntu
+
 You can run these commands to view the guide locally, temporarily.
+
+```bash
+sudo apt install pandoc # if you don't yet have pandoc installed
+make
+```
 
 |Technology|Command Line|
 |---|---|
@@ -25,3 +46,8 @@ You can run these commands to view the guide locally, temporarily.
 |**Ruby**|`ruby -run -ehttpd . -p8080`|
 
 Then visit: [http://localhost:8000](http://localhost:8000)
+
+### See Also
+
+- [Docker](https://www.docker.com/)
+- [Pandoc](https://pandoc.org/installing.html)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+nodeguide.com
+=============
+
+Local installation
+------------------
+
+### Linux - Debian/ Ubuntu
+
+```bash
+git clone git@github.com:felixge/nodeguide.com.git
+cd nodeguide.com 
+sudo apt install pandoc # if you don't yet have pandoc installed
+make
+```
+
+### Viewing the Guide
+
+You can run these commands to view the guide locally, temporarily.
+
+|Technology|Command Line|
+|---|---|
+|**PHP**|`php -S localhost:8000`|
+|**Python**|`python -m SimpleHTTPServer 8000`|
+|**Python - twistd**|`twistd -n web -p 8080 --path .`|
+|**Ruby**|`ruby -run -ehttpd . -p8080`|
+
+Then visit: [http://localhost:8000](http://localhost:8000)

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,4 @@
+web:
+  build: .
+  ports:
+    - 8080:80 # override port 80 which will typically be used for local Apache/ Nginx


### PR DESCRIPTION
Great guide - thanks for that. With [nodeguide.com currently down](https://github.com/felixge/nodeguide.com/issues/29), thought it worthwhile to add a very basic (Linux-centric, currently) installation guide.